### PR TITLE
add overwrite flag to unzip

### DIFF
--- a/bin/install-protoc
+++ b/bin/install-protoc
@@ -7,5 +7,5 @@ URL="https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/$
 
 pushd /usr/local
 sudo curl --location --silent --output "${ARCHIVE}" "${URL}"
-sudo unzip ${ARCHIVE}
+sudo unzip -o ${ARCHIVE}
 popd


### PR DESCRIPTION
#### What change does this introduce?

adds the `-o` flag to unzip for travis protoc installs.

#### Why make this change?

currently the input gets stalled on custom build images where the protoc files have already been installed (see make-files/issues#39).

#### What approach will be taken?

overwrite with the assumed to be newer downloaded files.

#### What issues does this relate to?

- make-files/issues#39
